### PR TITLE
Fix missing dependencies for Next.js build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lucide-react": "^0.294.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
-    "tailwind-merge": "^2.0.0"
+    "tailwind-merge": "^2.0.0",
+    "@radix-ui/react-slot": "^1.2.3",
+    "tailwindcss-animate": "^1.0.7"
   }
 }


### PR DESCRIPTION
## Summary
- add `@radix-ui/react-slot` and `tailwindcss-animate` to `package.json`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e71e5a8f8832ca41d0a8e986b2a5b