### PR TITLE
Fix disappearing players due to inactivity

### DIFF
--- a/app/api/game-state/route.ts
+++ b/app/api/game-state/route.ts
@@ -170,6 +170,15 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ success: false })
 
+      case "heartbeat":
+        // Update last active time without changing position
+        if (gameState.players.has(data.playerId)) {
+          const player = gameState.players.get(data.playerId)!
+          player.lastUpdate = now
+        }
+
+        return NextResponse.json({ success: true })
+
       case "leave":
         if (gameState.players.has(data.playerId)) {
           gameState.players.delete(data.playerId)


### PR DESCRIPTION
## Summary
- keep players alive with `heartbeat` API endpoint
- send heartbeat from client when idle

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint invalid options)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f952dc0d4832c82a709cce1758f65